### PR TITLE
Enable manual trigger for Ktor App workflow

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,7 +1,7 @@
 name: Run latest Ktor App (remote)
 
-#on:
-#  workflow_dispatch:
+on:
+  workflow_dispatch:
 
 jobs:
   run:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The change enables the `workflow_dispatch` trigger, allowing the workflow to be manually run from the GitHub Actions UI.