### PR TITLE
Add AI instructions and initial API routes for project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+Project-specific AI instructions are maintained in [docs/ai-instructions.md](docs/ai-instructions.md).
+
+Read that file first and follow its layer and dependency rules.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+Project-specific AI instructions are maintained in [docs/ai-instructions.md](docs/ai-instructions.md).
+
+Read that file first and follow its layer and dependency rules.
+

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -1,0 +1,26 @@
+# AI Instructions
+
+This repository provides an open API built with Kotlin and Ktor.
+
+## Project shape
+
+- `controller`: HTTP-facing entrypoints. Handle request parsing, validation, response mapping, and error translation.
+- `domain`: business rules and application use cases. Keep this layer free of framework and persistence concerns.
+- `data`: persistence and external integration. Put repository implementations, DTOs, and database access here.
+
+## Dependency rules
+
+- `controller` may depend on `domain`.
+- `data` may depend on `domain`.
+- `domain` must not depend on `controller` or `data`.
+- Use Koin for dependency wiring only. Keep object creation and module registration in DI modules.
+
+## Implementation guidance
+
+- Prefer small, explicit use cases in `domain`.
+- Keep Ktor-specific types out of `domain`.
+- Keep database or transport DTOs out of `controller` unless they are response/request models.
+- Validate input as early as practical, and keep validation rules close to the use case when they are business rules.
+- Use `suspend` for I/O paths.
+- Preserve API compatibility where possible, since this project is intended for public use.
+

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -24,3 +24,5 @@ This repository provides an open API built with Kotlin and Ktor.
 - Use `suspend` for I/O paths.
 - Preserve API compatibility where possible, since this project is intended for public use.
 - Treat Swagger/OpenAPI as part of the public API contract. Keep route behavior and `src/main/resources/openapi/documentation.yaml` aligned.
+- Keep `plugins/Routing.kt` thin. Put endpoint handlers into feature-specific `Route` extensions under `controller`, and add new route groups there instead of growing the bootstrap file.
+- When route-level error mapping starts to repeat, move it into a shared Ktor plugin such as `StatusPages` rather than expanding individual handlers.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -23,4 +23,4 @@ This repository provides an open API built with Kotlin and Ktor.
 - Validate input as early as practical, and keep validation rules close to the use case when they are business rules.
 - Use `suspend` for I/O paths.
 - Preserve API compatibility where possible, since this project is intended for public use.
-
+- Treat Swagger/OpenAPI as part of the public API contract. Keep route behavior and `src/main/resources/openapi/documentation.yaml` aligned.

--- a/src/main/kotlin/com/dignicate/p30a/controller/automobile/AutomobileRoutes.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/automobile/AutomobileRoutes.kt
@@ -1,0 +1,46 @@
+package com.dignicate.p30a.controller.automobile
+
+import com.dignicate.p30a.controller.ErrorResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.resources.Resource
+import io.ktor.server.response.respond
+import io.ktor.server.resources.get
+import io.ktor.server.routing.Route
+import org.koin.java.KoinJavaComponent.getKoin
+
+fun Route.automobileRoutes() {
+    get<Root.Automobile.V1.Companies> { request ->
+        val controller: AutomobileController = getKoin().get()
+        try {
+            val companies = controller.getCompanies(request.limit, request.page)
+            call.respond(HttpStatusCode.OK, companies)
+        } catch (e: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message ?: "Invalid input", 400))
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Unexpected error", 500))
+        }
+    }
+}
+
+@Resource("/")
+internal class Root {
+    @Resource("/automobile")
+    class Automobile(
+        @Suppress("unused")
+        val parent: Root = Root()
+    ) {
+        @Resource("/v1")
+        class V1(
+            @Suppress("unused")
+            val parent: Automobile = Automobile()
+        ) {
+            @Resource("/companies")
+            class Companies(
+                @Suppress("unused")
+                val parent: V1 = V1(),
+                val limit: Int = 10,
+                val page: Int = 1
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dignicate/p30a/controller/automobile/AutomobileRoutes.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/automobile/AutomobileRoutes.kt
@@ -3,6 +3,7 @@ package com.dignicate.p30a.controller.automobile
 import com.dignicate.p30a.controller.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.resources.Resource
+import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.resources.get
 import io.ktor.server.routing.Route

--- a/src/main/kotlin/com/dignicate/p30a/controller/common/CommonRoutes.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/common/CommonRoutes.kt
@@ -2,17 +2,19 @@ package com.dignicate.p30a.controller.common
 
 import io.ktor.http.Url
 import io.ktor.resources.Resource
+import io.ktor.server.application.call
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.resources.get
 import io.ktor.server.routing.Route
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 fun Route.commonRoutes() {
     get<Root> {
         call.respondRedirect(Url("https://freeapi.dignicate.com/swagger"))
     }
     get<Root.Redirect> { request ->
-        delay(request.delayMs)
+        delay(request.delayMs.milliseconds)
         call.respondRedirect(request.url)
     }
 }

--- a/src/main/kotlin/com/dignicate/p30a/controller/common/CommonRoutes.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/common/CommonRoutes.kt
@@ -1,0 +1,29 @@
+package com.dignicate.p30a.controller.common
+
+import io.ktor.http.Url
+import io.ktor.resources.Resource
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.resources.get
+import io.ktor.server.routing.Route
+import kotlinx.coroutines.delay
+
+fun Route.commonRoutes() {
+    get<Root> {
+        call.respondRedirect(Url("https://freeapi.dignicate.com/swagger"))
+    }
+    get<Root.Redirect> { request ->
+        delay(request.delayMs)
+        call.respondRedirect(request.url)
+    }
+}
+
+@Resource("/")
+internal class Root {
+    @Resource("/redirect")
+    class Redirect(
+        @Suppress("unused")
+        val parent: Root = Root(),
+        val delayMs: Long = 0L,
+        val url: String,
+    )
+}

--- a/src/main/kotlin/com/dignicate/p30a/plugins/Routing.kt
+++ b/src/main/kotlin/com/dignicate/p30a/plugins/Routing.kt
@@ -1,68 +1,15 @@
 package com.dignicate.p30a.plugins
 
-import com.dignicate.p30a.controller.ErrorResponse
-import com.dignicate.p30a.controller.automobile.AutomobileController
-import io.ktor.http.*
-import io.ktor.resources.Resource
+import com.dignicate.p30a.controller.automobile.automobileRoutes
+import com.dignicate.p30a.controller.common.commonRoutes
 import io.ktor.server.application.*
 import io.ktor.server.plugins.swagger.*
-import io.ktor.server.resources.get
-import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.delay
-import org.koin.java.KoinJavaComponent.getKoin
 
 fun Application.configureRouting() {
     routing {
-        get<Root> {
-            call.respondRedirect(Url("https://freeapi.dignicate.com/swagger"))
-        }
-        get<Root.Redirect> { request ->
-            delay(request.delayMs)
-            call.respondRedirect(request.url)
-        }
-        get<Root.Automobile.V1.Companies> { request ->
-            val controller: AutomobileController = getKoin().get()
-            try {
-                val companies = controller.getCompanies(request.limit, request.page)
-                call.respond(HttpStatusCode.OK, companies)
-            } catch (e: IllegalArgumentException) {
-                call.respond(HttpStatusCode.BadRequest, ErrorResponse(e.message ?: "Invalid input", 400))
-            } catch (e: Exception) {
-                call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Unexpected error", 500))
-            }
-        }
+        commonRoutes()
+        automobileRoutes()
         swaggerUI(path = "swagger", swaggerFile = "openapi/documentation.yaml")
-    }
-}
-
-@Resource("/")
-private class Root {
-    @Resource("/redirect")
-    class Redirect(
-        @Suppress("unused")
-        val parent: Root = Root(),
-        val delayMs: Long = 0L,
-        val url: String,
-    )
-
-    @Resource("/automobile")
-    class Automobile(
-        @Suppress("unused")
-        val parent: Root = Root()
-    ) {
-        @Resource("/v1")
-        class V1(
-            @Suppress("unused")
-            val parent: Automobile = Automobile()
-        ) {
-            @Resource("/companies")
-            class Companies(
-                @Suppress("unused")
-                val parent: V1 = V1(),
-                val limit: Int = 10,
-                val page: Int = 1
-            )
-        }
     }
 }


### PR DESCRIPTION
This pull request introduces project-specific AI instructions and refactors the routing logic to improve maintainability and clarity. The main changes include adding clear architectural guidance for contributors, extracting route definitions into feature-specific files, and simplifying the routing bootstrap file.

**Documentation and Guidance Improvements:**

* Added `docs/ai-instructions.md` to provide detailed project structure, dependency rules, and implementation guidance for contributors, emphasizing separation of concerns and API contract alignment.
* Introduced `AGENTS.md` and `CLAUDE.md` to direct AI agents and contributors to the main instructions and layering rules. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R6) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R6)

**Routing Refactor:**

* Extracted root and redirect route logic into `commonRoutes` in `controller/common/CommonRoutes.kt`, and automobile company listing routes into `automobileRoutes` in `controller/automobile/AutomobileRoutes.kt`, each with their own resource classes. [[1]](diffhunk://#diff-bd4a1e93a9e684432e225a19c5fd1a8c3fbb61c1b19103e4d612f0bcb7b7b772R1-R31) [[2]](diffhunk://#diff-d58b05adeea6fcfcc753ceb11f91fca31859d66e33fbab906ec016906b487f74R1-R47)
* Simplified `plugins/Routing.kt` by removing inlined route definitions and instead invoking the new `commonRoutes()` and `automobileRoutes()` extension functions, making the routing bootstrap file thinner and more maintainable.