### PR TITLE
Refactor time feature

### DIFF
--- a/src/main/kotlin/com/dignicate/p30a/controller/di/Module.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/di/Module.kt
@@ -1,7 +1,7 @@
 package com.dignicate.p30a.controller.di
 
 import com.dignicate.p30a.controller.automobile.AutomobileController
-import com.dignicate.p30a.controller.currenttime.CurrentTimeController
+import com.dignicate.p30a.controller.time.CurrentTimeController
 import org.koin.dsl.module
 
 

--- a/src/main/kotlin/com/dignicate/p30a/controller/time/CurrentTimeController.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/time/CurrentTimeController.kt
@@ -1,6 +1,6 @@
-package com.dignicate.p30a.controller.currenttime
+package com.dignicate.p30a.controller.time
 
-import com.dignicate.p30a.domain.currenttime.GetCurrentTimeUseCase
+import com.dignicate.p30a.domain.time.GetCurrentTimeUseCase
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 

--- a/src/main/kotlin/com/dignicate/p30a/controller/time/CurrentTimeResponse.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/time/CurrentTimeResponse.kt
@@ -1,4 +1,4 @@
-package com.dignicate.p30a.controller.currenttime
+package com.dignicate.p30a.controller.time
 
 @kotlinx.serialization.Serializable
 data class CurrentTimeResponse(

--- a/src/main/kotlin/com/dignicate/p30a/controller/time/TimeRoutes.kt
+++ b/src/main/kotlin/com/dignicate/p30a/controller/time/TimeRoutes.kt
@@ -1,4 +1,4 @@
-package com.dignicate.p30a.controller.currenttime
+package com.dignicate.p30a.controller.time
 
 import com.dignicate.p30a.controller.ErrorResponse
 import io.ktor.http.HttpStatusCode
@@ -8,8 +8,8 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import org.koin.java.KoinJavaComponent.getKoin
 
-fun Route.currentTimeRoutes() {
-    get("/current-time") {
+fun Route.timeRoutes() {
+    get("/time/v1/current") {
         val controller: CurrentTimeController = getKoin().get()
         try {
             call.respond(HttpStatusCode.OK, controller.getCurrentTime())

--- a/src/main/kotlin/com/dignicate/p30a/data/di/Module.kt
+++ b/src/main/kotlin/com/dignicate/p30a/data/di/Module.kt
@@ -2,11 +2,11 @@ package com.dignicate.p30a.data.di
 
 import com.dignicate.p30a.data.automobile.AutomobileRepositoryImpl
 import com.dignicate.p30a.data.automobile.CountryDataStore
-import com.dignicate.p30a.data.currenttime.CurrentTimeRepositoryImpl
+import com.dignicate.p30a.data.time.CurrentTimeRepositoryImpl
 import com.dignicate.p30a.data.common.MongoDbClientWrapper
 import com.dignicate.p30a.data.di.config.DatabaseConfig
 import com.dignicate.p30a.domain.automobile.AutomobileRepository
-import com.dignicate.p30a.domain.currenttime.CurrentTimeRepository
+import com.dignicate.p30a.domain.time.CurrentTimeRepository
 import org.koin.dsl.module
 
 

--- a/src/main/kotlin/com/dignicate/p30a/data/time/CurrentTimeRepositoryImpl.kt
+++ b/src/main/kotlin/com/dignicate/p30a/data/time/CurrentTimeRepositoryImpl.kt
@@ -1,7 +1,7 @@
-package com.dignicate.p30a.data.currenttime
+package com.dignicate.p30a.data.time
 
-import com.dignicate.p30a.domain.currenttime.CurrentTime
-import com.dignicate.p30a.domain.currenttime.CurrentTimeRepository
+import com.dignicate.p30a.domain.time.CurrentTime
+import com.dignicate.p30a.domain.time.CurrentTimeRepository
 import java.time.Instant
 
 class CurrentTimeRepositoryImpl(

--- a/src/main/kotlin/com/dignicate/p30a/domain/di/Module.kt
+++ b/src/main/kotlin/com/dignicate/p30a/domain/di/Module.kt
@@ -1,7 +1,7 @@
 package com.dignicate.p30a.domain.di
 
 import com.dignicate.p30a.domain.automobile.GetCompaniesUseCase
-import com.dignicate.p30a.domain.currenttime.GetCurrentTimeUseCase
+import com.dignicate.p30a.domain.time.GetCurrentTimeUseCase
 import org.koin.dsl.module
 
 

--- a/src/main/kotlin/com/dignicate/p30a/domain/time/CurrentTimeDomainObject.kt
+++ b/src/main/kotlin/com/dignicate/p30a/domain/time/CurrentTimeDomainObject.kt
@@ -1,4 +1,4 @@
-package com.dignicate.p30a.domain.currenttime
+package com.dignicate.p30a.domain.time
 
 import java.time.Instant
 

--- a/src/main/kotlin/com/dignicate/p30a/domain/time/CurrentTimeRepository.kt
+++ b/src/main/kotlin/com/dignicate/p30a/domain/time/CurrentTimeRepository.kt
@@ -1,4 +1,4 @@
-package com.dignicate.p30a.domain.currenttime
+package com.dignicate.p30a.domain.time
 
 interface CurrentTimeRepository {
     suspend fun getCurrentTime(): Result<CurrentTime>

--- a/src/main/kotlin/com/dignicate/p30a/domain/time/GetCurrentTimeUseCase.kt
+++ b/src/main/kotlin/com/dignicate/p30a/domain/time/GetCurrentTimeUseCase.kt
@@ -1,4 +1,4 @@
-package com.dignicate.p30a.domain.currenttime
+package com.dignicate.p30a.domain.time
 
 class GetCurrentTimeUseCase(
     private val repository: CurrentTimeRepository

--- a/src/main/kotlin/com/dignicate/p30a/plugins/Routing.kt
+++ b/src/main/kotlin/com/dignicate/p30a/plugins/Routing.kt
@@ -2,7 +2,7 @@ package com.dignicate.p30a.plugins
 
 import com.dignicate.p30a.controller.automobile.automobileRoutes
 import com.dignicate.p30a.controller.common.commonRoutes
-import com.dignicate.p30a.controller.currenttime.currentTimeRoutes
+import com.dignicate.p30a.controller.time.timeRoutes
 import io.ktor.server.application.*
 import io.ktor.server.plugins.swagger.*
 import io.ktor.server.routing.*
@@ -11,7 +11,7 @@ fun Application.configureRouting() {
     routing {
         commonRoutes()
         automobileRoutes()
-        currentTimeRoutes()
+        timeRoutes()
         swaggerUI(path = "swagger", swaggerFile = "openapi/documentation.yaml")
     }
 }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -31,7 +31,7 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/Company"
-  /current-time:
+  /time/v1/current:
     get:
       description: "Returns the current UTC time in multiple formats."
       responses:


### PR DESCRIPTION
This pull request refactors the "current time" feature by renaming and reorganizing related files and code from the `currenttime` package to a new `time` package. It also updates the API route and OpenAPI documentation to reflect these changes. The main goal is to improve code organization and make the naming more consistent.

**Refactoring and renaming for consistency:**

* Renamed all files and packages related to "current time" from `currenttime` to `time`, including controllers, domain objects, repositories, use cases, and response models. [[1]](diffhunk://#diff-9383650f5deda0882a831494f83f7ee03622bd15e6259241abdf2385a9785181L1-R3) [[2]](diffhunk://#diff-7fa7f71d33ae017f6bd60e886b12c8c72f58f2efe1599178f906121a0a6b5a5aL1-R1) [[3]](diffhunk://#diff-93fd2cb20935807c85a75b619c4d15230b9543d634deb1c166a4e9a581fc9209L1-R1) [[4]](diffhunk://#diff-e62facbdfadcab75865644efe61224c8e7423ab5bfe75af0729d5ce8f6a6107dL1-R4) [[5]](diffhunk://#diff-17b39909d8833b1b2d9fb5d7d0b20cf493510f513a3ea46d31d0d8318ffbf06eL1-R1) [[6]](diffhunk://#diff-e98753c23723fc78fc89d4dbb3fa74dd944e116555d58b4445d9b01e1463b4efL1-R1) [[7]](diffhunk://#diff-366932c960422e6cba8f2a31344118cc5edd10d83c3d2ca0fcfae887b9a3f3c9L1-R1)
* Updated dependency injection modules (`Module.kt` files in controller, data, and domain layers) to use the new package and class names. [[1]](diffhunk://#diff-988ec485d19635fa77abc86e22bd1dedfacc01386ce578732c2be8c0dd455d6eL4-R4) [[2]](diffhunk://#diff-f8f521255fe303ac7410c722decc978ae2bf5e6f8c704379607d99186a30a62fL5-R9) [[3]](diffhunk://#diff-e2a761c1b2270703e357b9f98629e036aa0207b896b33d4bed78be5f81d31203L4-R4)

**API changes:**

* Changed the route for fetching the current time from `/current-time` to `/time/v1/current` and renamed the route registration function to `timeRoutes`. [[1]](diffhunk://#diff-93fd2cb20935807c85a75b619c4d15230b9543d634deb1c166a4e9a581fc9209L11-R12) [[2]](diffhunk://#diff-3654f05664215d89ff26ac98fbbed572b038d8c70678d5f15cd143b190d7b8d4L5-R5) [[3]](diffhunk://#diff-3654f05664215d89ff26ac98fbbed572b038d8c70678d5f15cd143b190d7b8d4L14-R14)
* Updated the OpenAPI documentation to reflect the new route path.