### PR TITLE
Standardize version management and response headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 
+import org.apache.tools.ant.filters.ReplaceTokens
+
 val kotlin_version: String by project
 val logback_version: String by project
 val ktor_version: String by project
@@ -10,7 +12,7 @@ plugins {
 }
 
 group = "com.dignicate"
-version = "0.0.1"
+version = "0.1.0"
 
 application {
     mainClass.set("io.ktor.server.netty.EngineMain")
@@ -22,6 +24,12 @@ application {
 
 repositories {
     mavenCentral()
+}
+
+tasks.processResources {
+    filesMatching(listOf("application.yaml", "openapi/documentation.yaml")) {
+        filter<ReplaceTokens>("tokens" to mapOf("appVersion" to project.version.toString()))
+    }
 }
 
 dependencies {

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -24,6 +24,9 @@ This repository provides an open API built with Kotlin and Ktor.
 - Use `suspend` for I/O paths.
 - Preserve API compatibility where possible, since this project is intended for public use.
 - Treat Swagger/OpenAPI as part of the public API contract. Keep route behavior and `src/main/resources/openapi/documentation.yaml` aligned.
+- Treat `build.gradle.kts` `project.version` as the single source of truth for the application version.
+- Keep `src/main/resources/application.yaml` and `src/main/resources/openapi/documentation.yaml` on tokenized version placeholders; Gradle `processResources` injects the concrete version into build outputs.
+- Keep the `X-App-Version` response header aligned with `project.version`. When changing the version, update `build.gradle.kts` rather than writing concrete version strings into resource templates unless the template token itself needs to change.
 - For small outbound HTTP integrations in `data`, using a direct HTTP client implementation is acceptable.
 - Introduce a shared HTTP wrapper or adapter only when multiple integrations need the same timeout, retry, logging, tracing, auth, or testing behavior.
 - Keep `plugins/Routing.kt` thin. Put endpoint handlers into feature-specific `Route` extensions under `controller`, and add new route groups there instead of growing the bootstrap file.

--- a/src/main/kotlin/com/dignicate/p30a/Application.kt
+++ b/src/main/kotlin/com/dignicate/p30a/Application.kt
@@ -5,6 +5,7 @@ import com.dignicate.p30a.data.di.dataModule
 import com.dignicate.p30a.data.di.databaseModule
 import com.dignicate.p30a.domain.di.domainModule
 import com.dignicate.p30a.plugins.configureRouting
+import com.dignicate.p30a.plugins.VersionHeaders
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
@@ -17,6 +18,9 @@ import org.koin.ktor.plugin.Koin
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
 }
+
+val Application.appVersion: String
+    get() = environment.config.property("app.version").getString()
 
 @Suppress("unused") // Referenced in application.conf
 fun Application.module() {
@@ -34,5 +38,6 @@ fun Application.module() {
         modules(controllerModule)
     }
     install(Resources)
+    install(VersionHeaders)
     configureRouting()
 }

--- a/src/main/kotlin/com/dignicate/p30a/plugins/VersionHeaders.kt
+++ b/src/main/kotlin/com/dignicate/p30a/plugins/VersionHeaders.kt
@@ -1,0 +1,14 @@
+package com.dignicate.p30a.plugins
+
+import com.dignicate.p30a.appVersion
+import io.ktor.server.application.createApplicationPlugin
+
+const val AppVersionHeaderName = "X-App-Version"
+
+val VersionHeaders = createApplicationPlugin(name = "VersionHeaders") {
+    val version = application.appVersion
+
+    onCall { call ->
+        call.response.headers.append(AppVersionHeaderName, version)
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,3 +4,5 @@ ktor:
             - com.dignicate.p30a.ApplicationKt.module
     deployment:
         port: "$PORT:8080"
+app:
+    version: "@appVersion@"

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.1
 info:
   title: Free API by Dignicate,
   description: Implemented with Ktor.
-  version: 1.0.0
+  version: "@appVersion@"
 servers:
   - url: 'https://freeapi.dignicate.com'
   - url: 'http://localhost:8081'

--- a/src/test/kotlin/com/dignicate/p30a/plugins/VersionHeadersTest.kt
+++ b/src/test/kotlin/com/dignicate/p30a/plugins/VersionHeadersTest.kt
@@ -1,0 +1,34 @@
+package com.dignicate.p30a.plugins
+
+import io.ktor.client.request.get
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VersionHeadersTest {
+    @Test
+    fun `adds app version header to responses`() = testApplication {
+        environment {
+            config = MapApplicationConfig("app.version" to "0.1.0")
+        }
+
+        application {
+            install(VersionHeaders)
+            routing {
+                get("/ping") {
+                    call.respondText("ok")
+                }
+            }
+        }
+
+        val response = client.get("/ping")
+
+        assertEquals("0.1.0", response.headers[AppVersionHeaderName])
+    }
+}


### PR DESCRIPTION
This pull request introduces a standardized approach for handling the application version across the codebase, ensuring that the version is managed centrally and consistently surfaced in both configuration and API responses. The most significant changes are the introduction of a `VersionHeaders` plugin that adds the `X-App-Version` response header, and the use of tokenized version placeholders in resource files, with Gradle injecting the actual version during the build process.

**Version management and exposure:**
* Added a `VersionHeaders` Ktor plugin (`src/main/kotlin/com/dignicate/p30a/plugins/VersionHeaders.kt`) that appends the `X-App-Version` header to all HTTP responses, sourcing the version from application configuration.
* Introduced an `appVersion` property in `Application.kt` to retrieve the version from the config (`app.version`).
* Registered the `VersionHeaders` plugin in the main application module to enable the header across all endpoints.

**Build and configuration alignment:**
* Updated documentation to specify that `build.gradle.kts` is the single source of truth for the application version, with resource files using tokenized placeholders (`@appVersion@`) replaced at build time.
* Modified `application.yaml` and `openapi/documentation.yaml` to use the `@appVersion@` placeholder for version, which is injected by Gradle during the build. [[1]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061R7-R8) [[2]](diffhunk://#diff-122a7e8c5032c74137f126818fc095b5a6c2d8ac90b118c335c286748ecff6e5L5-R5)

**Testing:**
* Added a test (`VersionHeadersTest`) to verify that the `X-App-Version` header is correctly set in HTTP responses.